### PR TITLE
clean: try to publish to my registry instead of BCR fork

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,5 +1,5 @@
 {
-  "homepage": "https://www.hdlfactory.com",
+  "homepage": "https://hdlfactory.com/post/2025/02/04/typeset-your-own-ebooks-easily-with-bazel-ebook",
   "maintainers": [
     {
       "name": "Filip Filmar",

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,8 @@ jobs:
     uses: "bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v0.2.2"
     with:
       tag_name: ${{ inputs.tag_name }}
-      registry_fork: filmil/bazel-central-registry
+      registry_fork: filmil/bazel-registry
+      registry: filmil/bazel-registry
       attest: false
     permissions:
       contents: write


### PR DESCRIPTION
I'm not sure how to prevent the PR to be created in bazel-central-registry