### PR TITLE
feat: allow filegroups in markdown_lib rule

### DIFF
--- a/build/rules.bzl
+++ b/build/rules.bzl
@@ -373,7 +373,6 @@ markdown_lib = rule(
     attrs = {
         "srcs": attr.label_list(
             allow_files = [".md"],
-            providers = [EbookInfo],
             doc = "The markdown source files",
         ),
         "deps": attr.label_list(

--- a/integration/BUILD.bazel
+++ b/integration/BUILD.bazel
@@ -16,6 +16,11 @@ asymptote(
   deps = ["//images:test2"],
 )
 
+filegroup(
+    name = "test_filegroup",
+    srcs = ["filegroup_test.md"],
+)
+
 markdown_lib(
   name = "md",
   srcs = [
@@ -23,6 +28,7 @@ markdown_lib(
     "book.ch002.md",
     "//images:md",
     "book.ch004.md",
+    ":test_filegroup",
   ],
   deps = [
     "//images:dot",

--- a/integration/filegroup_test.md
+++ b/integration/filegroup_test.md
@@ -1,0 +1,3 @@
+# Filegroup Test
+
+This markdown file is included via a filegroup, to verify that `markdown_lib` accepts `filegroup`s.


### PR DESCRIPTION
## Feature: allow filegroups in markdown_lib rule

**Summary of changes:**
- Removed the `providers = [EbookInfo]` restriction from the `srcs` attribute of the `markdown_lib` rule to support accepting filegroups that contain Markdown files.
- Added a test in `//integration` to verify this behavior.

This pull request has been created by an automated coding assistant, with
human supervision.

Prompt:
modify the markdown_lib rule so that it can accept filegroups of MD files, not just MD files
add a test in //integration that confirms the feature
send pr
