### PR TITLE
feat: add toc attribute to ebook_pdf rule

### DIFF
--- a/build/rules.bzl
+++ b/build/rules.bzl
@@ -573,6 +573,10 @@ def _ebook_pdf_impl(ctx):
     inputs = [epub_metadata, title_yaml] + markdowns + figures
     log_file = ctx.actions.declare_file("{}.log".format(ctx.attr.name))
 
+    args = list(ctx.attr.args)
+    if ctx.attr.toc:
+        args += ["--toc"]
+
     ctx.actions.run_shell(
         progress_message = "Building PDF for: {}".format(name),
         inputs = inputs + additional_inputs,
@@ -587,7 +591,7 @@ def _ebook_pdf_impl(ctx):
             script=script_cmd,
             epub_metadata=_strip_reference_dir(dir_reference, epub_metadata.path),
             ebook_pdf=_strip_reference_dir(dir_reference, ebook_pdf.path),
-            args=" ".join(ctx.attr.args),
+            args=" ".join(args),
             markdowns=" ".join(markdowns_paths),
             log=log_file.path,
         ))
@@ -620,6 +624,10 @@ ebook_pdf = rule(
         'args': attr.string_list(
             doc = 'Any additional args to insert',
             allow_empty = True,
+        ),
+        "toc": attr.bool(
+            doc = "Set to true to generate a Table of Contents",
+            default = False,
         ),
         "_script": attr.label(
           default="@rules_bid//build:docker_run",

--- a/integration/BUILD.bazel
+++ b/integration/BUILD.bazel
@@ -42,6 +42,7 @@ ebook_pdf(
   deps = [":md"],
   metadata_xml = "epub-metadata.xml",
   title_yaml = "title.yaml",
+  toc = True,
 )
 
 ebook_kindle(
@@ -60,6 +61,7 @@ pandoc_standalone_html(
         "--katex=https://cdn.jsdelivr.net/npm/katex@0.16.21/dist/",
     ],
     title = "This is a test title",
+    toc = True,
 )
 
 # This packages the files, but ignores the dir paths, which are important.


### PR DESCRIPTION
## Feature: Add `toc` boolean flag to `ebook_pdf` and `pandoc_standalone_html` rules

**Summary of changes:**
- Modified the `ebook_pdf` rule in `build/rules.bzl` to accept a `toc` boolean flag (like `pandoc_chunked_html` already does), and updated `_ebook_pdf_impl` to pass `--toc` to the pandoc execution if this flag is true.
- Confirmed that `pandoc_standalone_html` in `build/pandoc.bzl` already inherently accepts the `toc` flag and processes it appropriately.
- Added tests in `//integration/BUILD.bazel` to test building with `toc = True` for both `ebook_pdf` and `pandoc_standalone_html`.

This pull request has been created by an automated coding assistant, with
human supervision.

Prompt:
new feature, new pr: modify rules ebook_pdf and html to accept a boolean flag `toc` like the chunked_html rule. run tests, repair any failures, add a test in //integration and create pr
