### PR TITLE
chore: upgrade bazel_dep versions

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,7 +6,7 @@ module(
 
 bazel_dep(
     name = "gazelle",
-    version = "0.51.0",
+    version = "0.51.3",
     repo_name = "bazel_gazelle",
 )
 bazel_dep(name = "buildifier_prebuilt", version = "8.5.1.2")
@@ -15,15 +15,15 @@ bazel_dep(name = "rules_pkg", version = "1.2.0")
 bazel_dep(name = "rules_bid", version = "2.2.2")
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
 bazel_dep(name = "bazel_lib", version = "3.3.1")
-bazel_dep(name = "rules_go", version = "0.60.0")
+bazel_dep(name = "rules_go", version = "0.61.1")
 
 bazel_dep(name = "stardoc", version = "0.8.1", dev_dependency = True)
 
-bazel_dep(name = "protobuf", version = "35.0")
-bazel_dep(name = "rules_android", version = "0.7.2")
+bazel_dep(name = "protobuf", version = "35.1")
+bazel_dep(name = "rules_android", version = "0.7.3")
 
 #bazel_dep(name = "platforms", version = "1.1.0")
-#bazel_dep(name = "rules_cc", version = "0.2.18")
+#bazel_dep(name = "rules_cc", version = "0.2.19")
 bazel_dep(name = "rules_shell", version = "0.8.0")
 bazel_dep(name = "rules_python_gazelle_plugin", version = "2.0.2")
 


### PR DESCRIPTION
This PR upgrades bazel_dep versions in MODULE.bazel to the latest available in the BCR.

* gazelle: 0.51.0 -> 0.51.3
* rules_go: 0.60.0 -> 0.61.1
* protobuf: 35.0 -> 35.1
* rules_android: 0.7.2 -> 0.7.3
* rules_cc: 0.2.18 -> 0.2.19