### PR TITLE
chore: upgrade bazel_dep versions

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -25,7 +25,7 @@ bazel_dep(name = "rules_android", version = "0.7.3")
 #bazel_dep(name = "platforms", version = "1.1.0")
 #bazel_dep(name = "rules_cc", version = "0.2.19")
 bazel_dep(name = "rules_shell", version = "0.8.0")
-bazel_dep(name = "rules_python_gazelle_plugin", version = "2.0.2")
+bazel_dep(name = "rules_python_gazelle_plugin", version = "2.1.0-rc0")
 
 bazel_ebook_extension = use_extension(
     "//:extensions.bzl",
@@ -39,7 +39,7 @@ use_repo(
     "pandoc_include",
 )
 
-bazel_dep(name = "rules_python", version = "2.0.2")
+bazel_dep(name = "rules_python", version = "2.1.0-rc0")
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(


### PR DESCRIPTION
This PR upgrades bazel_dep versions in MODULE.bazel to the latest available in the BCR.

* rules_python_gazelle_plugin: 2.0.2 -> 2.1.0-rc0
* rules_python: 2.0.2 -> 2.1.0-rc0