### PR TITLE
fix: skip the release when nothing changed

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -37,24 +37,35 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           release_branches: main
+          # Without this the action bumps the patch version on every run, even
+          # when no commit landed since the last tag. The cron then released the
+          # same tree again and again. `false` makes the action emit an empty
+          # `new_tag` when no commit asks for a release, and the guards below
+          # then skip the release and the publication.
+          default_bump: false
       - name: Create a GitHub release
+        if: ${{ steps.tag_version.outputs.new_tag != '' }}
         uses: ncipollo/release-action@v1
         with:
           tag: ${{ steps.tag_version.outputs.new_tag }}
           generateReleaseNotes: true
       - name: Get release tag
+        if: ${{ steps.tag_version.outputs.new_tag != '' }}
         id: get_version
         run: echo "VERSION=${{ steps.tag_version.outputs.new_tag }}" >> $GITHUB_ENV
       - name: Get repo name
+        if: ${{ steps.tag_version.outputs.new_tag != '' }}
         id: get_repo_name
         run: echo "REPO_NAME=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')" >> $GITHUB_ENV
       - name: "Publish source archive"
+        if: ${{ steps.tag_version.outputs.new_tag != '' }}
         uses: thedoctor0/zip-release@0.7.5
         with:
           type: 'zip'
           filename: "${{ env.REPO_NAME }}-${{ env.VERSION }}.zip"
           exclusions: '*.git* /*node_modules/* .editorconfig /bazel-*'
       - name: "Upload source archive"
+        if: ${{ steps.tag_version.outputs.new_tag != '' }}
         uses: ncipollo/release-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## The problem

The cron releases the same tree over and over. `git rev-list --count v2.1.9..v2.1.10` returns 0. The last two tags, v2.1.9 and v2.1.10, hold the same tree.

The cause is `mathieudutour/github-tag-action`. Its `default_bump` input
defaults to `patch`. The action therefore bumps the version on every run, even
when no commit landed since the last tag.

This is not a local problem. 31 of your 34 repositories with two or more tags
have zero commits between their last two tags.

## The change

This copies the pattern that `rules_shar` and `bazel_rootfs` already use, and
matches the pull requests you merged in `bazel_rules_latex_host`, `lit2md` and
`bazel_graphviz`:

* `default_bump: false` makes the action emit an empty `new_tag` when no commit
  asks for a release.
* Each release step in the `tag` job now runs only when `new_tag` is not empty.

## This repository is a special case

**This repository does not publish automatically.** Its `tag-and-release.yml` holds a `tag` job and nothing else, and no workflow calls `publish.yml`, which offers only `workflow_call` and `workflow_dispatch`. So there is no publication step to guard here. The change stops the empty tags and the empty releases, which is the same root cause.

## What changes for you

A commit title must follow conventional commits (`fix:`, `feat:` or
`BREAKING:`) to cause a release. A plain title produces no release. The SOP
requires that style already, so the two agree.

## Summary of commits

* `fix: skip the release when nothing changed` — edits `.github/workflows/tag-and-release.yml` only. 1 file
  changed.

## Verification

A script made this edit. The same script reproduces, character for character,
the three edits you already reviewed and merged, and leaves `rules_shar` and
`bazel_rootfs` untouched because they are already correct.

I then parsed the result with `yaml.safe_load` and checked that `default_bump`
is `false` and sits on the tag action step and no other, that no release step
is left unguarded, and that each job guard names the output the `tag` job
actually declares.

This pull request has been created by an automated coding assistant, with
human supervision.

Prompt used to generate this pull request:

  when done: check all my GitHub repos, and if any have defined BCR and private registry publication workflows, send PRs to modify workflows to *skip* publication if no changes
